### PR TITLE
chore: migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.347.0",
     "@aws-cdk/integ-runner": "^2.77.0-alpha.0",
     "@aws-cdk/integ-tests-alpha": "^2.77.0-alpha.0",
     "@ryansonshine/commitizen": "^4.2.8",
@@ -47,7 +48,6 @@
     "@semantic-release/exec": "^6.0.3",
     "@types/jest": "^29.2.4",
     "@types/node": "^18.11.15",
-    "aws-sdk": "^2.1282.0",
     "constructs": "^10.0.0",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "husky": "^6.0.0",
@@ -58,11 +58,6 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.77.0"
-  },
-  "overrides": {
-    "aws-sdk": {
-      "xml2js": "^0.4.23"
-    }
   },
   "config": {
     "commitizen": {

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -1,10 +1,12 @@
-const { CloudWatchLogs } = require('aws-sdk');
+const { CloudWatchLogs } = require("@aws-sdk/client-cloudwatch-logs");
 module.exports = (...regions) => {
     regions.forEach(region => {
         const logs = new CloudWatchLogs({
             region,
-            accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-            secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+            credentials: {
+                accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+                secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+            },
         });
         logs.describeLogGroups({}, (err, data) => {
             if (err) console.error(err);


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/awslabs/aws-break-glass-role/issues/9

*Description of changes:*
Migrate AWS SDK for JavaScript v2 APIs to v3
```console
$ npx aws-sdk-js-codemod@latest -t v2-to-v3 scripts/cleanup.js
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
